### PR TITLE
Remove `pin_compatible('numpy')` for `numpy` run requirement.  

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
     - cross-compile-get-torch.patch
 
 build:
-  number: 3
+  number: 4
   skip: cuda_compiler_version == "None" or win or osx
   string: torch${{ pytorch | replace(".", "") | replace("*", "") }}_cuda${{ cuda_compiler_version | replace(".", "") }}_py${{ python | version_to_buildstring }}_h${{ hash }}_${{ build_number }}
   script:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -61,7 +61,7 @@ requirements:
   run:
     - python
     - pytorch ${{ pytorch }}.*[build="*${{ torch_proc_type }}*"]
-    - ${{ pin_compatible('numpy') }}
+    - numpy
     - if: cuda_compiler_version != "None"
       then: cuda-version =${{ cuda_compiler_version }}
     - gitpython


### PR DESCRIPTION
We don't link against numpy's C API so we should be compatible with any version at runtime.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
